### PR TITLE
Study count

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Aldo A. Adriazola <a3dev@outlook.com>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,3 +11,8 @@ History
 ------------------
 
 * Minor fixes
+
+0.2.0 (2021-04-24)
+------------------
+
+* added get_study_count function

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,12 @@ Basic Usage
         fmt="csv",
     )
 
+    # Get the count of studies related to Coronavirus and COVID.
+    # ClinicalTrials limits API queries to 1000 records
+    # Count of studies may be useful to build loops when you want to retrieve more than 1000 records
+
+    ct.get_study_count(search_expr="Coronavirus+COVID")
+
     # Read the csv data in Pandas
     import pandas as pd
 

--- a/pytrials/client.py
+++ b/pytrials/client.py
@@ -114,14 +114,25 @@ class ClinicalTrials:
             else:
                 raise ValueError("Format argument has to be either 'csv' or 'json'")
 
-    def get_study_count(self, search_expr, fields=["NCTId"]):
-        if not set(fields).issubset(self.study_fields):
-            raise ValueError(
-                "One of the fields is not valid! Check the study_fields attribute for a list of valid ones."
-            )
+    def get_study_count(self, search_expr):
+        """Returns study count for specified search expression
+
+        Retrieves the count of studies matching the text entered in search_expr. 
+
+        Args:
+            search_expr (str): A string containing a search expression as specified by
+                `their documentation <https://clinicaltrials.gov/api/gui/ref/syntax#searchExpr>`_.
+
+        Returns:
+            An integer
+            
+        Raises:
+            ValueError: The search expression cannot be blank.
+        """
+        if not set(search_expr):
+            raise ValueError("The search expression cannot be blank.")
         else:
-            concat_fields = ",".join(fields)
-            req = f"study_fields?expr={search_expr}&max_rnk=1&fields={concat_fields}"
+            req = f"study_fields?expr={search_expr}&max_rnk=1&fields=NCTId"
             url = f"{self._BASE_URL}{self._QUERY}{req}&{self._JSON}"
             returned_data = json_handler(url)
             study_count = returned_data['StudyFieldsResponse']['NStudiesFound']

--- a/pytrials/client.py
+++ b/pytrials/client.py
@@ -4,12 +4,14 @@ from pytrials.utils import json_handler, csv_handler
 class ClinicalTrials:
     """ClinicalTrials API client
 
-    Provides functions to easily access the ClinicalTrials.gov API (https://clinicaltrials.gov/api/) 
+    Provides functions to easily access the ClinicalTrials.gov API
+    (https://clinicaltrials.gov/api/)
     in Python.
 
     Attributes:
         study_fields: List of all study fields you can use in your query.
-        api_info: Tuple containing the API version number and the last time the database was updated.
+        api_info: Tuple containing the API version number and the last
+        time the database was updated.
     """
 
     _BASE_URL = "https://clinicaltrials.gov/api/"
@@ -41,20 +43,20 @@ class ClinicalTrials:
 
     def get_full_studies(self, search_expr, max_studies=50):
         """Returns all content for a maximum of 100 study records.
-        
-        Retrieves information from the full studies endpoint, which gets all study fields. 
-        This endpoint can only output JSON (Or not-supported XML) format and does not allow 
+
+        Retrieves information from the full studies endpoint, which gets all study fields.
+        This endpoint can only output JSON (Or not-supported XML) format and does not allow
         requests for more than 100 studies at once.
 
         Args:
-            search_expr (str): A string containing a search expression as specified by 
+            search_expr (str): A string containing a search expression as specified by
                 `their documentation <https://clinicaltrials.gov/api/gui/ref/syntax#searchExpr>`_.
             max_studies (int): An integer indicating the maximum number of studies to return.
                 Defaults to 50.
 
         Returns:
-            dict: Object containing the information queried with the search expression. 
-        
+            dict: Object containing the information queried with the search expression.
+
         Raises:
             ValueError: The number of studies can only be between 1 and 100
         """
@@ -69,13 +71,13 @@ class ClinicalTrials:
 
     def get_study_fields(self, search_expr, fields, max_studies=50, fmt="csv"):
         """Returns study content for specified fields
-        
-        Retrieves information from the study fields endpoint, which acquires specified information 
-        from a large (max 1000) studies. To see a list of all possible fields, check the class' 
+
+        Retrieves information from the study fields endpoint, which acquires specified information
+        from a large (max 1000) studies. To see a list of all possible fields, check the class'
         study_fields attribute.
 
         Args:
-            search_expr (str): A string containing a search expression as specified by 
+            search_expr (str): A string containing a search expression as specified by
                 `their documentation <https://clinicaltrials.gov/api/gui/ref/syntax#searchExpr>`_.
             fields (list(str)): A list containing the desired information fields.
             max_studies (int): An integer indicating the maximum number of studies to return.
@@ -83,12 +85,12 @@ class ClinicalTrials:
             fmt (str): A string indicating the output format, csv or json. Defaults to csv.
 
         Returns:
-            Either a dict, if fmt='json', or a list of records (e.g. a list of lists), if fmt='csv. 
+            Either a dict, if fmt='json', or a list of records (e.g. a list of lists), if fmt='csv.
             Both containing the maximum number of study fields queried using the specified search expression.
-        
+
         Raises:
             ValueError: The number of studies can only be between 1 and 1000
-            ValueError: One of the fields is not valid! Check the study_fields attribute 
+            ValueError: One of the fields is not valid! Check the study_fields attribute
                 for a list of valid ones.
             ValueError: Format argument has to be either 'csv' or 'json'
         """
@@ -111,6 +113,19 @@ class ClinicalTrials:
 
             else:
                 raise ValueError("Format argument has to be either 'csv' or 'json'")
+
+    def get_study_count(self, search_expr, fields=["NCTId"]):
+        if not set(fields).issubset(self.study_fields):
+            raise ValueError(
+                "One of the fields is not valid! Check the study_fields attribute for a list of valid ones."
+            )
+        else:
+            concat_fields = ",".join(fields)
+            req = f"study_fields?expr={search_expr}&max_rnk=1&fields={concat_fields}"
+            url = f"{self._BASE_URL}{self._QUERY}{req}&{self._JSON}"
+            returned_data = json_handler(url)
+            study_count = returned_data['StudyFieldsResponse']['NStudiesFound']
+            return study_count
 
     def __repr__(self):
         return f"ClinicalTrials.gov client v{self.api_info[0]}, database last updated {self.api_info[1]}"

--- a/pytrials/utils.py
+++ b/pytrials/utils.py
@@ -8,7 +8,7 @@ def request_ct(url):
     """Performs a get request that provides a (somewhat) useful error message."""
     try:
         response = requests.get(url)
-    except:
+    except ImportError:
         raise IOError(
             "Couldn't retrieve the data, check your search expression or try again later."
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ universal = 1
 
 [flake8]
 exclude = docs
+max-line-length = 120
 
 [aliases]
 test = pytest

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/jvfe/pytrials",
-    version="0.1.2",
+    version='0.1.2',
     zip_safe=False,
 )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 """Tests for `pytrials` package."""
-import pytest
 from pytest import raises
 from pytrials.client import ClinicalTrials
 
@@ -45,7 +44,7 @@ def test_study_fields_json():
 
 
 def test_study_fake_fields():
-    with raises(ValueError) as invalid_field:
+    with raises(ValueError):
         ct.get_study_fields(
             search_expr="Coronavirus+COVID",
             fields=["NCTId", "I AM NOT A REAL FIELD"],
@@ -55,10 +54,16 @@ def test_study_fake_fields():
 
 
 def test_study_fake_fmt():
-    with raises(ValueError) as invalid_fmt:
+    with raises(ValueError):
         ct.get_study_fields(
             search_expr="Coronavirus+COVID",
             fields=["NCTId", "BriefTitle"],
             max_studies=50,
             fmt="I AM NOT A REAL FORMAT",
         )
+
+
+def test_study_count():
+    ct.get_study_count(
+        search_expr="Coronavirus+COVID"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,8 @@
-import pytest
+# import pytest
 from pytest import raises
 from pytrials.utils import request_ct
 
 
 def test_fake_url():
-    with raises(IOError) as exception:
+    with raises(IOError):
         request_ct("i am a fake url")
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-# import pytest
 from pytest import raises
 from pytrials.utils import request_ct
 


### PR DESCRIPTION
Hello.  I recently used your pytrials for a project.  I found the need to retrieve fields for some search expressions where there were more than 1000 matching rows.  In order to get all the rows, it was necessary to loop through the rows 1000 at a time.  I created the get_study_count function to help with this task and thought I would share the code with anyone else who needs it.  This is my first time contributing to a Python project, so I had some difficulty with flake8 and tox.  I changed the max-line-length to 120 to work around some of the errors in flake.  I have a Mac with an M1 processor and was unable to test with Python versions prior to 3.8.   Thanks.  Muito obrigado.