### PR TITLE
Added classic prefix to API base URL to circumvent breaking changes

### DIFF
--- a/pytrials/client.py
+++ b/pytrials/client.py
@@ -14,7 +14,7 @@ class ClinicalTrials:
         time the database was updated.
     """
 
-    _BASE_URL = "https://clinicaltrials.gov/api/"
+    _BASE_URL = "https://classic.clinicaltrials.gov/api/"
     _INFO = "info/"
     _QUERY = "query/"
     _JSON = "fmt=json"


### PR DESCRIPTION
Fixes #9 

Adds `classic` prefix to API base URL to circumvent breakage caused by undocumented API changes. 