### PR TITLE
Raise exception if API request returns error status

### DIFF
--- a/pytrials/utils.py
+++ b/pytrials/utils.py
@@ -8,6 +8,9 @@ def request_ct(url):
     """Performs a get request that provides a (somewhat) useful error message."""
     try:
         response = requests.get(url)
+        response.raise_for_status()
+    except requests.HTTPError as ex:
+        raise ex
     except ImportError:
         raise ImportError(
             "Couldn't retrieve the data, check your search expression or try again later."


### PR DESCRIPTION
Context: #9 

If requests to the ClinicalTrials API fail, the error should not occur upon parsing, when `.json()` is called. Instead, the library will raise an exception for HTTP error status codes.